### PR TITLE
Set Strict-Transport-Security to minimum recommended

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,6 @@
 let securityHeaders = {
 	"Content-Security-Policy" : "upgrade-insecure-requests",
-	"Strict-Transport-Security" : "max-age=1000",
+	"Strict-Transport-Security" : "max-age=2592000",
 	"X-Xss-Protection" : "1; mode=block",
 	"X-Frame-Options" : "DENY",
 	"X-Content-Type-Options" : "nosniff",


### PR DESCRIPTION
securityheaders.com now reports:

    The "max-age" directive is too small. The minimum recommended value is 2592000 (30 days).

The existing default for "Strict-Transport-Security" : "max-age=1000" is now reported by securityheaders.com to be 'too low'.
Changes just this setting to match the minimum recommended.