### PR TITLE
Allow informational request to pass-through + Replace CSP with Permissions Policy

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -5,7 +5,7 @@ const securityHeaders = {
     "X-Frame-Options": "DENY",
     "X-Content-Type-Options": "nosniff",
     "Referrer-Policy": "strict-origin-when-cross-origin",
-    "Feature-Policy": "geolocation none;midi none;notifications none;push none;sync-xhr none;microphone none;camera none;magnetometer none;gyroscope none;speaker self;vibrate none;fullscreen self;payment none;"
+    "Permissions-Policy": "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
 },
     sanitiseHeaders = {
         Server: ""


### PR DESCRIPTION
Informational requests such as websocket protocol upgrade requests fail currently.  Allowing responses with status codes less than 200 will solve this.

CSP is replace with Permissions Policy.